### PR TITLE
Add GitHub Actions CI for Linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - .github/workflows/CI.yml
+      - src/**
+  pull_request:
+    paths:
+      - .github/workflows/CI.yml
+      - src/**
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Init
+      run: |
+        wget -qO- http://media.steampowered.com/client/runtime/steam-runtime-sdk_latest.tar.xz \
+        | sudo tar --strip-components=1 --one-top-level="/valve/steam-runtime" -xvJf -
+        sudo /valve/steam-runtime/setup.sh --target="i386 amd64" --release --auto-upgrade
+        sudo cp /usr/bin/objcopy /valve/steam-runtime/bin
+        sudo chmod +x ./src/devtools/{bin/vpc,bin/vpc_linux,bin/linux/ccache,gendbg.sh}
+    - name: Install
+      working-directory: src
+      run: ./devtools/bin/vpc /tf_mod +game /mksln games
+    - name: Build
+      working-directory: src
+      run: make -j$(nproc) -f games.mak
+    - uses: actions/upload-artifact@v2
+      with:
+        name: tfport_linux
+        path: game/tf_mod/bin


### PR DESCRIPTION
Linux only for now because GitHub Actions doesn't have VS2013, and building fails with `windows-latest` (VS2017/v141_xp): https://github.com/Margen67/TF2-Base/runs/669613490#step:6:1

GitHub Actions also doesn't have an old enough XCode for 32-bit support, let alone 5.0.2. Not that it would run on the latest version of macOS anyway: https://github.com/actions/virtual-environments/issues/859#issuecomment-626281416

macOS builds might be possible with Travis though: https://docs.travis-ci.com/user/reference/osx/#xcode-64